### PR TITLE
kdeconnect-kde: fix Update.ps1

### DIFF
--- a/kdeconnect-kde/Update.ps1
+++ b/kdeconnect-kde/Update.ps1
@@ -25,8 +25,8 @@ function global:au_GetLatest {
 			continue
 		}
 		$version    = $release.Node.version
-		$url64      = $release.Node.artifacts.artifact.location
-        $checksum64 = $release.Node.artifacts.artifact.checksum
+		$url64      = $release.Node.SelectSingleNode('artifacts/artifact/location').InnerText
+        $checksum64 = $release.Node.SelectSingleNode('artifacts/artifact/checksum').InnerText
 		break
 	}
 


### PR DESCRIPTION
PowerShell comes with some magic - dynamic properties like `$release.Node.artifacts.artifact.checksum` gives a string if the element has no attributes and an XmlElement object otherwise. Use SelectSingleNode avoids such magic and surprises.

With current Update.ps1, the checksum contains an invalid string `System.Xml.XmlElement` as shown in Chocolatey verification logs: https://gist.github.com/choco-bot/63a1005566a5b5c45ea77c98a082078f#file-install-txt-L238